### PR TITLE
Add android 12 compatibility with new syntax

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -39,8 +39,6 @@
 				<param name="onload" value="true" />
 			</feature>
 		</config-file>
-
-
 		<config-file target="AndroidManifest.xml" parent="/manifest/application/activity">
 			<intent-filter>
 				<action android:name="android.intent.action.VIEW" />
@@ -52,11 +50,41 @@
 				<action android:name="android.intent.action.VIEW" />
 				<category android:name="android.intent.category.DEFAULT" />
 				<category android:name="android.intent.category.BROWSABLE" />
-				<data android:scheme="$DEEPLINK_SCHEME" android:host="$DEEPLINK_HOST" android:pathPrefix="$ANDROID_PATH_PREFIX" />
-				<data android:scheme="$DEEPLINK_2_SCHEME" android:host="$DEEPLINK_2_HOST" android:pathPrefix="$ANDROID_2_PATH_PREFIX" />
-				<data android:scheme="$DEEPLINK_3_SCHEME" android:host="$DEEPLINK_3_HOST" android:pathPrefix="$ANDROID_3_PATH_PREFIX" />
-				<data android:scheme="$DEEPLINK_4_SCHEME" android:host="$DEEPLINK_4_HOST" android:pathPrefix="$ANDROID_4_PATH_PREFIX" />
-				<data android:scheme="$DEEPLINK_5_SCHEME" android:host="$DEEPLINK_5_HOST" android:pathPrefix="$ANDROID_5_PATH_PREFIX" />
+				<data android:scheme="$DEEPLINK_SCHEME" />
+				<data android:host="$DEEPLINK_HOST" />
+				<data android:pathPrefix="$ANDROID_PATH_PREFIX" />
+			</intent-filter>
+			<intent-filter android:autoVerify="true">
+				<action android:name="android.intent.action.VIEW" />
+				<category android:name="android.intent.category.DEFAULT" />
+				<category android:name="android.intent.category.BROWSABLE" />
+				<data android:scheme="$DEEPLINK_2_SCHEME" />
+				<data android:host="$DEEPLINK_2_HOST" />
+				<data android:pathPrefix="$ANDROID_2_PATH_PREFIX" />
+			</intent-filter>
+			<intent-filter android:autoVerify="true">
+				<action android:name="android.intent.action.VIEW" />
+				<category android:name="android.intent.category.DEFAULT" />
+				<category android:name="android.intent.category.BROWSABLE" />
+				<data android:scheme="$DEEPLINK_3_SCHEME" />
+				<data android:host="$DEEPLINK_3_HOST" />
+				<data android:pathPrefix="$ANDROID_3_PATH_PREFIX" />
+			</intent-filter>
+			<intent-filter android:autoVerify="true">
+				<action android:name="android.intent.action.VIEW" />
+				<category android:name="android.intent.category.DEFAULT" />
+				<category android:name="android.intent.category.BROWSABLE" />
+				<data android:scheme="$DEEPLINK_4_SCHEME" />
+				<data android:host="$DEEPLINK_4_HOST" />
+				<data android:pathPrefix="$ANDROID_4_PATH_PREFIX" />
+			</intent-filter>
+			<intent-filter android:autoVerify="true">
+				<action android:name="android.intent.action.VIEW" />
+				<category android:name="android.intent.category.DEFAULT" />
+				<category android:name="android.intent.category.BROWSABLE" />
+				<data android:scheme="$DEEPLINK_5_SCHEME" />
+				<data android:host="$DEEPLINK_5_HOST" />
+				<data android:pathPrefix="$ANDROID_5_PATH_PREFIX" />
 			</intent-filter>
 		</config-file>
 


### PR DESCRIPTION
- Modification nécessaire pour le support d'Android 12.
- Dans notre console et même pour les clients qui feront le rebranding, 5 erreurs sont détectées.

> Certains liens profonds ne fonctionnent pas
> Sur les versions antérieures à Android 12, les utilisateurs verront l'outil de sélection d'applis pour tous les liens. Sur Android 12 ou version ultérieure, les utilisateurs seront redirigés vers le navigateur Web pour les liens associés aux domaines dont la propriété n'a pas été validée. Une fois ces problèmes corrigés et une nouvelle version publiée, les utilisateurs devront mettre à jour leur appli pour que les liens fonctionnent.

- C'est logique d'avoir ces erreurs car le plugin qu'ont utilise, il permet d'associer à l’application 5 liens. Dans notre cas, on associe seulement le site de l'intranet.